### PR TITLE
Remove use of `Integer` constructor

### DIFF
--- a/src/main/java/com/github/johnynek/jarjar/Wildcard.java
+++ b/src/main/java/com/github/johnynek/jarjar/Wildcard.java
@@ -70,7 +70,7 @@ class Wildcard
                     int n = Integer.parseInt(new String(chars, mark, i - mark));
                     if (n > max)
                         max = n;
-                    parts.add(new Integer(n));
+                    parts.add(n);
                     mark = i--;
                     state = 0;
                 }


### PR DESCRIPTION
This constructor results in a deprecation warning at compile-time with recent JDKs.