### PR TITLE
Set up "push tag to release" workflow

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,0 +1,1 @@
+# Required by the release workflow

--- a/.bcr/config.yml
+++ b/.bcr/config.yml
@@ -1,0 +1,3 @@
+fixedReleaser:
+  login: eed3si9n
+  email: eed3si9n@gmail.com

--- a/.bcr/metadata.template.json
+++ b/.bcr/metadata.template.json
@@ -1,0 +1,15 @@
+{
+  "homepage": "https://github.com/bazeltools/bazel_jar_jar",
+  "maintainers": [
+    {
+      "email": "eed3si9n@gmail.com",
+      "github": "eed3si9n",
+      "name": "Eugene Yokota"
+    }
+  ],
+  "repository": [
+    "github:bazeltools/bazel_jar_jar"
+  ],
+  "versions": [],
+  "yanked_versions": {}
+}

--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -1,0 +1,17 @@
+bcr_test_module:
+  module_path: test
+  matrix:
+    platform:
+      - debian10
+      - ubuntu2004
+      - macos
+      - macos_arm64
+      - windows
+  tasks:
+    run_test_module:
+      name: Run test module
+      platform: ${{ platform }}
+      build_targets:
+        - //...
+      test_targets:
+        - //...

--- a/.bcr/source.template.json
+++ b/.bcr/source.template.json
@@ -1,0 +1,5 @@
+{
+  "integrity": "",
+  "strip_prefix": "{REPO}-{VERSION}",
+  "url": "https://github.com/{OWNER}/{REPO}/releases/download/{TAG}/{REPO}-{TAG}.tar.gz"
+}

--- a/.github/workflows/ci.bazelrc
+++ b/.github/workflows/ci.bazelrc
@@ -1,0 +1,1 @@
+# Required by the release workflow

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,18 @@
+# Based on
+# https://github.com/bazel-contrib/rules-template/blob/07fefdbc09d7ca2a49d24220e00dac2efc2bf9b7/.github/workflows/release.yml
+
+# Cut a release whenever a new tag is pushed to the repo.
+# You should use an annotated tag, like `git tag -a v1.2.3`
+# and put the release notes into the commit message for the tag.
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+jobs:
+  release:
+    uses: bazel-contrib/.github/.github/workflows/release_ruleset.yaml@v5
+    with:
+      release_files: bazel_jar_jar-*.tar.gz

--- a/.github/workflows/release_prep.sh
+++ b/.github/workflows/release_prep.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+# Based on
+# https://github.com/bazel-contrib/rules-template/blob/07fefdbc09d7ca2a49d24220e00dac2efc2bf9b7/.github/workflows/release_prep.sh
+
+set -o errexit -o nounset -o pipefail
+
+# Set by GH actions, see
+# https://docs.github.com/en/actions/learn-github-actions/environment-variables#default-environment-variables
+TAG=${GITHUB_REF_NAME}
+# The prefix is chosen to match what GitHub generates for source archives
+PREFIX="bazel_jar_jar-${TAG:1}"
+ARCHIVE="bazel_jar_jar-$TAG.tar.gz"
+git archive --format=tar --prefix=${PREFIX}/ ${TAG} | gzip > $ARCHIVE
+SHA=$(shasum -a 256 $ARCHIVE | awk '{print $1}')
+
+cat << EOF
+## Using Bzlmod
+
+1. Enable with \`common --enable_bzlmod\` in \`.bazelrc\` (default with Bazel 7).
+2. Add to your \`MODULE.bazel\` file:
+
+\`\`\`starlark
+bazel_dep(name = "bazel_jar_jar", version = "${TAG:1}")
+\`\`\`
+
+## Using WORKSPACE
+
+Paste this snippet into your \`WORKSPACE.bazel\` file:
+
+\`\`\`starlark
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+http_archive(
+    name = "bazel_jar_jar",
+    sha256 = "${SHA}",
+    strip_prefix = "${PREFIX}",
+    url = "https://github.com/bazeltools/bazel_jar_jar/releases/download/${TAG}/${ARCHIVE}",
+)
+
+load(
+    "@com_github_johnynek_bazel_jar_jar//:jar_jar.bzl",
+    "jar_jar_repositories",
+)
+
+jar_jar_repositories()
+\`\`\`
+EOF

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,8 @@
+## Releasing
+
+As one-time setup, follow the first step of https://github.com/bazel-contrib/publish-to-bcr#how-it-works.
+
+1. Create an annotated tag with `git tag -a v1.2.3`, where the message will be used in the release notes.
+2. Push the tag with `git push origin v1.2.3` to trigger the creation of a GitHub pre-release as well as a Bazel Central Registry (BCR) PR.
+   The PR will be associated with the GitHub account configured in `.bcr/config.yml`.
+3. Review the release notes on https://github.com/bazeltools/bazel_jar_jar/releases and mark the release as final.


### PR DESCRIPTION
Adopts the release workflow from
https://github.com/bazel-contrib/rules-template, which includes automatic publishing to the Bazel Central Registry (BCR).