### PR TITLE
Update `jarjar-abrams` version to 1.13.1

### DIFF
--- a/jar_jar.bzl
+++ b/jar_jar.bzl
@@ -24,8 +24,8 @@ def _http_jar_with_servers(name, path, sha256, servers):
 def jar_jar_repositories(servers=["https://repo1.maven.org/maven2"]):
     _http_jar_with_servers(
       name = "jvm__jarjar_abrams_assembly",
-      path = "/com/eed3si9n/jarjarabrams/jarjar-abrams-assembly_2.12/1.11.0/jarjar-abrams-assembly_2.12-1.11.0.jar",
-      sha256 = "114478b75fd0fb4f595f19f5dc05cfe6744a449b12f7f6ea15543e2ce10d9266",
+      path = "/com/eed3si9n/jarjarabrams/jarjar-abrams-assembly_2.12/1.13.1/jarjar-abrams-assembly_2.12-1.13.1.jar",
+      sha256 = "8e6492fd22fad431317c6810d8e10bd49844c1569a7f0de848bd8f536637a409",
       servers = servers,
     )
     _http_jar_with_servers(


### PR DESCRIPTION
Newer version of `jarjar-abrams` update the `org.objectweb.asm.Opcodes.ASM#` value used for some of the `ClassVisitor` subclasses, thus avoiding failure like:

```
Exception in thread "main" java.io.IOException: Unable to transform org/apache/kafka/clients/consumer/internals/SubscriptionState$FetchStates.class
	at com.eed3si9n.jarjar.util.JarTransformer.process(JarTransformer.java:43)
	at com.eed3si9n.jarjar.util.JarProcessorChain.process(JarProcessorChain.java:38)
	at com.eed3si9n.jarjar.JJProcessor.process(JJProcessor.scala:108)
	at com.eed3si9n.jarjarabrams.Shader$.$anonfun$bytecodeShader$6(Shader.scala:119)
	at com.eed3si9n.jarjarabrams.Shader$.$anonfun$shadeFile$1(Shader.scala:20)
	at com.eed3si9n.jarjarabrams.Zip$.$anonfun$transformJarFile$3(Zip.scala:62)
	at com.eed3si9n.jarjarabrams.Zip$.$anonfun$transformJarFile$3$adapted(Zip.scala:55)
	at scala.collection.Iterator.foreach(Iterator.scala:943)
	at scala.collection.Iterator.foreach$(Iterator.scala:943)
	at scala.collection.AbstractIterator.foreach(Iterator.scala:1431)
	at com.eed3si9n.jarjarabrams.Zip$.$anonfun$transformJarFile$2(Zip.scala:55)
	at com.eed3si9n.jarjarabrams.Zip$.$anonfun$transformJarFile$2$adapted(Zip.scala:53)
	at com.eed3si9n.jarjarabrams.Using.apply(Using.scala:24)
	at com.eed3si9n.jarjarabrams.Zip$.$anonfun$transformJarFile$1(Zip.scala:53)
	at com.eed3si9n.jarjarabrams.Using.apply(Using.scala:24)
	at com.eed3si9n.jarjarabrams.Zip$.transformJarFile(Zip.scala:51)
	at com.eed3si9n.jarjarabrams.Shader$.shadeFile(Shader.scala:19)
	at com.eed3si9n.jarjarabrams.Main.process(Main.scala:25)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
	at com.eed3si9n.jarjar.MainUtil.runMain(MainUtil.java:39)
	at com.eed3si9n.jarjarabrams.Main$.main(Main.scala:32)
	at com.eed3si9n.jarjarabrams.Main.main(Main.scala)
	at com.github.johnynek.jarjar.Main.main(Main.java:5)
Caused by: java.lang.UnsupportedOperationException: PermittedSubclasses requires ASM9
	at org.objectweb.asm.ClassVisitor.visitPermittedSubclass(ClassVisitor.java:281)
	at org.objectweb.asm.ClassVisitor.visitPermittedSubclass(ClassVisitor.java:284)
	at org.objectweb.asm.commons.ClassRemapper.visitPermittedSubclass(ClassRemapper.java:226)
	at org.objectweb.asm.ClassReader.accept(ClassReader.java:706)
	at org.objectweb.asm.ClassReader.accept(ClassReader.java:424)
	at com.eed3si9n.jarjar.util.JarTransformer.process(JarTransformer.java:41)
	... 25 more
```