### PR TITLE
Enable bzlmod for release workflow

### DIFF
--- a/.github/workflows/ci.bazelrc
+++ b/.github/workflows/ci.bazelrc
@@ -1,1 +1,2 @@
 # Required by the release workflow
+build --enable_bzlmod

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,6 @@ on:
 
 jobs:
   release:
-    uses: bazel-contrib/.github/.github/workflows/release_ruleset.yaml@v5
+    uses: bazel-contrib/.github/.github/workflows/release_ruleset.yaml@v7
     with:
       release_files: bazel_jar_jar-*.tar.gz


### PR DESCRIPTION
When I pushed tag 'v0.1.6' the release workflow failed (see https://github.com/bazeltools/bazel_jar_jar/actions/runs/13838887980). The test step threw the following:

```
ERROR: Skipping '//...': error loading package under directory '': error loading package '~/.cache/bazel-repo/bazel/_bazel_runner/3399e9710025216540c9400ff7b0a534/external/bazel_tools/src/conditions': Label '//tools/windows:windows_config.bzl' is invalid because 'tools/windows' is not a package; perhaps you meant to put the colon here: '//:tools/windows/windows_config.bzl'?
ERROR: error loading package under directory '': error loading package '~/.cache/bazel-repo/bazel/_bazel_runner/3399e9710025216540c9400ff7b0a534/external/bazel_tools/src/conditions': Label '//tools/windows:windows_config.bzl' is invalid because 'tools/windows' is not a package; perhaps you meant to put the colon here: '//:tools/windows/windows_config.bzl'?
```

The current version of the Test action enables bzlmod, so we update the release flow to do the same.

I went ahead and retagged v0.1.6 with these changes and the workflow was successful.